### PR TITLE
fix: correct US-1 Pools content labels

### DIFF
--- a/above-ground.html
+++ b/above-ground.html
@@ -8,19 +8,19 @@
   <meta property="og:site_name" content="US-1 Pools">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Above Ground Pools | US-1 Pools">
-  <meta property="og:description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, and steel systems with optional deck packages.">
+  <meta property="og:description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, steel, and Aquasport and Oasis hybrid options with optional deck packages.">
   <meta property="og:url" content="https://www.us1pools.com/above-ground">
-  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Above+Ground+Pools+%7C+US-1+Pools&amp;subtitle=Above-ground+pool+installs+from+US-1+Pools+including+vinyl+liner%2C+resin%2C+and+steel+systems+with+optional+deck+packages.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Above+Ground+Pools+%7C+US-1+Pools&amp;subtitle=Above-ground+pool+installs+from+US-1+Pools+including+vinyl+liner%2C+resin%2C+steel%2C+and+Aquasport+and+Oasis+hybrid+options+with+optional+deck+packages.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Above Ground Pools | US-1 Pools social preview">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Above Ground Pools | US-1 Pools">
-  <meta name="twitter:description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, and steel systems with optional deck packages.">
-  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Above+Ground+Pools+%7C+US-1+Pools&amp;subtitle=Above-ground+pool+installs+from+US-1+Pools+including+vinyl+liner%2C+resin%2C+and+steel+systems+with+optional+deck+packages.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta name="twitter:description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, steel, and Aquasport and Oasis hybrid options with optional deck packages.">
+  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Above+Ground+Pools+%7C+US-1+Pools&amp;subtitle=Above-ground+pool+installs+from+US-1+Pools+including+vinyl+liner%2C+resin%2C+steel%2C+and+Aquasport+and+Oasis+hybrid+options+with+optional+deck+packages.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
   <meta name="twitter:image:alt" content="Above Ground Pools | US-1 Pools social preview">
 
-  <meta name="description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, and steel systems with optional deck packages." />
+  <meta name="description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, steel, and Aquasport and Oasis hybrid options with optional deck packages." />
   <meta name="ai-content-declaration" content="human-authored, human-edited" />
   <link rel="alternate" type="text/markdown" href="https://www.us1pools.com/llms-full.txt" />
   <link rel="icon" type="image/png" href="assets/images/logo.png" />
@@ -82,11 +82,11 @@
       <div class="container">
         <p class="eyebrow">Above Ground</p>
         <h1>Fast installs with clean, modern profiles.</h1>
-        <p>US-1 Pools installs above-ground pools with vinyl liner, resin, and steel options plus decks, stairs, and start-up service.</p>
+        <p>US-1 Pools installs above-ground pools with vinyl liner, resin, steel, and Aquasport or Oasis hybrid options plus decks, stairs, and start-up service.</p>
         <div class="page-meta">
           <span class="meta-chip">Vinyl liner</span>
           <span class="meta-chip">Resin systems</span>
-          <span class="meta-chip">Steel options</span>
+          <span class="meta-chip">Hybrid + steel</span>
         </div>
       </div>
     </section>
@@ -104,8 +104,8 @@
           </div>
         </div>
         <div class="image-card">
-          <img src="assets/images/gallery-05.webp" alt="Above-ground pool with wraparound deck and landscaped backyard" loading="lazy"  width="2500" height="1215" decoding="async"/>
-          <span class="image-caption">Representative above-ground deck package</span>
+          <img src="assets/images/pool-07.jpg" alt="Above-ground pool with retaining wall" loading="lazy"  width="2500" height="1875" decoding="async"/>
+          <span class="image-caption">Above-ground pool with retaining wall</span>
         </div>
       </div>
     </section>
@@ -113,21 +113,22 @@
     <section class="section split reveal">
       <div class="container content-grid">
         <div>
-          <p class="eyebrow">Yard-fit planning</p>
-          <h2>Above-ground installs can adapt to sloped yards.</h2>
-          <p class="section-sub">Some installs need retaining-wall or deck planning so the pool sits cleanly in the yard. We confirm the exact model, wall package, and site prep during the quote.</p>
+          <p class="eyebrow">Hybrid pools</p>
+          <h2>Aquasport and Oasis hybrid above-ground pools.</h2>
+          <p class="section-sub">Aquasport and Oasis are hybrid options to ask about when you want a stronger above-ground package with a clean finished profile. Oasis can only be recessed 27–30 inches in the ground.</p>
           <div class="model-list">
-            <span class="model-chip">Retaining walls</span>
-            <span class="model-chip">Deck planning</span>
-            <span class="model-chip">Site prep</span>
+            <span class="model-chip">Aquasport</span>
+            <span class="model-chip">Oasis</span>
+            <span class="model-chip">27–30 in. max recess</span>
           </div>
         </div>
         <div class="image-card">
-          <img src="assets/images/pool-07.jpg" alt="Round above-ground pool with a retaining wall" loading="lazy"  width="2500" height="1875" decoding="async"/>
-          <span class="image-caption">Above-ground pool with retaining wall</span>
+          <img src="assets/images/gallery-05.webp" alt="Hybrid Oasis above-ground pool with wraparound deck" loading="lazy"  width="2500" height="1215" decoding="async"/>
+          <span class="image-caption">Hybrid Oasis with deck package</span>
         </div>
       </div>
     </section>
+
 
     <section class="section reveal">
       <div class="container content-grid">

--- a/above-ground.html
+++ b/above-ground.html
@@ -8,19 +8,19 @@
   <meta property="og:site_name" content="US-1 Pools">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Above Ground Pools | US-1 Pools">
-  <meta property="og:description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, hybrid, and steel systems with optional deck packages.">
+  <meta property="og:description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, and steel systems with optional deck packages.">
   <meta property="og:url" content="https://www.us1pools.com/above-ground">
-  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Above+Ground+Pools+%7C+US-1+Pools&amp;subtitle=Above-ground+pool+installs+from+US-1+Pools+including+vinyl+liner%2C+resin%2C+hybrid%2C+and+steel+systems+with+optional+deck+packages.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Above+Ground+Pools+%7C+US-1+Pools&amp;subtitle=Above-ground+pool+installs+from+US-1+Pools+including+vinyl+liner%2C+resin%2C+and+steel+systems+with+optional+deck+packages.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Above Ground Pools | US-1 Pools social preview">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Above Ground Pools | US-1 Pools">
-  <meta name="twitter:description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, hybrid, and steel systems with optional deck packages.">
-  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Above+Ground+Pools+%7C+US-1+Pools&amp;subtitle=Above-ground+pool+installs+from+US-1+Pools+including+vinyl+liner%2C+resin%2C+hybrid%2C+and+steel+systems+with+optional+deck+packages.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta name="twitter:description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, and steel systems with optional deck packages.">
+  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Above+Ground+Pools+%7C+US-1+Pools&amp;subtitle=Above-ground+pool+installs+from+US-1+Pools+including+vinyl+liner%2C+resin%2C+and+steel+systems+with+optional+deck+packages.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
   <meta name="twitter:image:alt" content="Above Ground Pools | US-1 Pools social preview">
 
-  <meta name="description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, hybrid, and steel systems with optional deck packages." />
+  <meta name="description" content="Above-ground pool installs from US-1 Pools including vinyl liner, resin, and steel systems with optional deck packages." />
   <meta name="ai-content-declaration" content="human-authored, human-edited" />
   <link rel="alternate" type="text/markdown" href="https://www.us1pools.com/llms-full.txt" />
   <link rel="icon" type="image/png" href="assets/images/logo.png" />
@@ -82,11 +82,11 @@
       <div class="container">
         <p class="eyebrow">Above Ground</p>
         <h1>Fast installs with clean, modern profiles.</h1>
-        <p>US-1 Pools installs above-ground pools with vinyl liner, resin, hybrid, and steel options plus decks, stairs, and start-up service.</p>
+        <p>US-1 Pools installs above-ground pools with vinyl liner, resin, and steel options plus decks, stairs, and start-up service.</p>
         <div class="page-meta">
           <span class="meta-chip">Vinyl liner</span>
           <span class="meta-chip">Resin systems</span>
-          <span class="meta-chip">Hybrid + steel</span>
+          <span class="meta-chip">Steel options</span>
         </div>
       </div>
     </section>
@@ -95,8 +95,8 @@
       <div class="container content-grid">
         <div>
           <p class="eyebrow">Resin pools</p>
-          <h2>Genesis, Nakoma, and Discovery.</h2>
-          <p class="section-sub">Resin options hold up in humid summers and deliver clean lines with minimal upkeep. Project photos here show representative above-ground installs; exact wall materials are confirmed before quoting.</p>
+          <h2>Genesis, Nakoma, Discovery, and current options.</h2>
+          <p class="section-sub">Resin options hold up in humid summers and deliver clean lines with minimal upkeep. Some model lines change over time, so we confirm current availability before quoting.</p>
           <div class="model-list">
             <span class="model-chip">Genesis</span>
             <span class="model-chip">Nakoma</span>
@@ -113,18 +113,18 @@
     <section class="section split reveal">
       <div class="container content-grid">
         <div>
-          <p class="eyebrow">Hybrid pools</p>
-          <h2>AquaSport, Oasis, and Ultimate.</h2>
-          <p class="section-sub">Hybrid construction blends strength and style while keeping installs efficient. We confirm the specific frame and wall package during the quote.</p>
+          <p class="eyebrow">Yard-fit planning</p>
+          <h2>Above-ground installs can adapt to sloped yards.</h2>
+          <p class="section-sub">Some installs need retaining-wall or deck planning so the pool sits cleanly in the yard. We confirm the exact model, wall package, and site prep during the quote.</p>
           <div class="model-list">
-            <span class="model-chip">AquaSport</span>
-            <span class="model-chip">Oasis</span>
-            <span class="model-chip">Ultimate</span>
+            <span class="model-chip">Retaining walls</span>
+            <span class="model-chip">Deck planning</span>
+            <span class="model-chip">Site prep</span>
           </div>
         </div>
         <div class="image-card">
-          <img src="assets/images/pool-07.jpg" alt="Round above-ground pool installation" loading="lazy"  width="2500" height="1875" decoding="async"/>
-          <span class="image-caption">Representative round above-ground install</span>
+          <img src="assets/images/pool-07.jpg" alt="Round above-ground pool with a retaining wall" loading="lazy"  width="2500" height="1875" decoding="async"/>
+          <span class="image-caption">Above-ground pool with retaining wall</span>
         </div>
       </div>
     </section>

--- a/api/chat.js
+++ b/api/chat.js
@@ -17,13 +17,12 @@ ABOUT US-1 POOLS:
 
 PRODUCTS WE SELL:
 Above-Ground Pools:
-- Resin: Genesis, Nakoma, Discovery
-- Hybrid: AquaSport, Oasis, Ultimate
-- Steel: Coral Seas, Distinction, Eclipse, Serena, Southport
+- Resin/current options: Genesis, Nakoma, Discovery (availability can change)
+- Steel options: Coral Seas, Distinction, Eclipse, Serena, Southport
 - Vinyl Liners: Cardinal and Latham
 
 In-Ground Pools:
-- Fiberglass shells: Imagine Fiberglass and Pools by Genesis
+- Fiberglass shells: Imagine Fiberglass
 - Vinyl liner pools: steel/polymer wall systems with replaceable vinyl liner surfaces
 - Equipment: Pentair pumps, filters, heaters, automation
 - Upgrades: salt/oxygen sanitation, LED lighting, automation panels
@@ -72,7 +71,7 @@ SALES APPROACH:
 GUIDELINES:
 - Be friendly, helpful, and knowledgeable
 - Keep pool terminology precise: in-ground is a placement category; fiberglass, vinyl liner, and concrete/gunite are material/construction categories
-- Do not call a vinyl liner pool fiberglass or a fiberglass shell a liner pool
+- Do not call a vinyl liner pool fiberglass, a fiberglass shell a liner pool, or Genesis a fiberglass product
 - If asked about pricing, say we offer free quotes and they should contact us or visit
 - If you don't know something specific, direct them to call 919.441.0033
 - Never make up specific prices, inventory counts, or availability`;

--- a/api/chat.js
+++ b/api/chat.js
@@ -18,6 +18,7 @@ ABOUT US-1 POOLS:
 PRODUCTS WE SELL:
 Above-Ground Pools:
 - Resin/current options: Genesis, Nakoma, Discovery (availability can change)
+- Hybrid options: Aquasport and Oasis (Oasis can only be recessed 27–30 inches; confirm current availability)
 - Steel options: Coral Seas, Distinction, Eclipse, Serena, Southport
 - Vinyl Liners: Cardinal and Latham
 
@@ -25,7 +26,7 @@ In-Ground Pools:
 - Fiberglass shells: Imagine Fiberglass
 - Vinyl liner pools: steel/polymer wall systems with replaceable vinyl liner surfaces
 - Equipment: Pentair pumps, filters, heaters, automation
-- Upgrades: salt/oxygen sanitation, LED lighting, automation panels
+- Upgrades: salt/oxygen sanitation, equipment controls, automation panels
 
 Hot Tubs & Swim Spas:
 - Tranquility spas
@@ -33,7 +34,7 @@ Hot Tubs & Swim Spas:
 - Delivery, setup, and ongoing service included
 
 Pool Liners:
-- GLI Pool Products (vinyl liners, safety covers)
+- GLI Pool Products (vinyl liners, in-ground mesh safety covers, solid safety covers)
 - Latham Pools (liners and covers)
 - Cardinal Systems (liners)
 

--- a/calculator.html
+++ b/calculator.html
@@ -146,7 +146,7 @@
               </div>
               <div class="calculator-option" data-value="mid" data-addition-low="3000" data-addition-high="5000">
                 <h3>Mid-Level</h3>
-                <p>+ LED lighting, upgraded filter, heater.</p>
+                <p>+ upgraded filter, heater, automation-ready controls.</p>
                 <p><strong>+$3,000 - $5,000</strong></p>
               </div>
               <div class="calculator-option" data-value="premium" data-addition-low="8000" data-addition-high="12000">

--- a/docs/pool-type-material-guide.md
+++ b/docs/pool-type-material-guide.md
@@ -20,7 +20,7 @@ Purpose: keep site copy, captions, gallery filters, and client photo placement f
 
 - **Steel**: Steel wall/frame components; strong but rust/corrosion risk matters.
 - **Resin**: Hard plastic frame/top-rail/upright components; marketed for corrosion resistance. Resin is not the same thing as fiberglass.
-- **Hybrid**: Combination of steel wall/structure with resin components.
+- **Hybrid**: Hybrid above-ground systems need to be named by model when known. Cathy confirmed Aquasport and Oasis as hybrid options; Oasis can only be recessed 27–30 inches in the ground.
 - **Vinyl liner**: The interior liner material for above-ground pools. Do not label an above-ground pool as “fiberglass” unless the actual shell is fiberglass.
 
 ## Visual ID cheat sheet
@@ -37,8 +37,8 @@ Purpose: keep site copy, captions, gallery filters, and client photo placement f
 ## Site copy rules
 
 1. **Never use “in-ground” as if it means fiberglass.** In-ground is placement; fiberglass/vinyl/concrete are materials.
-2. **Never put a known liner photo under a fiberglass brand block.** The client specifically flagged `customer-pool-sunset.webp` as liner.
-3. **Use `Pools by Genesis` only when the surrounding copy makes clear it is a fiberglass shell brand.** Use `Genesis` by itself only in the above-ground model context, where it appears with Nakoma/Discovery.
+2. **Never put a known steel-wall or liner photo under a fiberglass brand block.** Cathy flagged multiple finished projects as steel wall in-ground, not generic fiberglass.
+3. **Do not use Genesis as a fiberglass brand on this site.** Cathy confirmed Genesis is not fiberglass and is being discontinued/not quite gone yet. Use `Genesis` only in the above-ground model context with Nakoma/Discovery, and avoid prominent claims unless availability is confirmed.
 4. **Use process photos carefully.** A liner-change photo can be useful on the liner page, but should be captioned as a replacement/process image, not a polished new-build glamour shot.
 5. **If client verification is pending, choose neutral language.** “In-ground pool project” is safer than “fiberglass pool” or “vinyl liner pool.”
 
@@ -46,22 +46,23 @@ Purpose: keep site copy, captions, gallery filters, and client photo placement f
 
 | Asset | Working classification | Confidence | Recommended use |
 | --- | --- | ---: | --- |
-| `assets/images/customer-pool-sunset.webp` | Finished in-ground vinyl liner pool | High; client flagged it as liner | Home hero/general in-ground, liner page, not fiberglass brand sections |
-| `assets/images/gallery-04.webp` | Fiberglass in-ground pool | High; client flagged it as fiberglass | Fiberglass/In-ground pages |
+| `assets/images/customer-pool-sunset.webp` | Steel wall in-ground pool | High; Cathy flagged this class of photos as steel wall in-ground | Home hero/general in-ground, liner-adjacent pages, not fiberglass brand sections |
+| `assets/images/gallery-04.webp` | In-ground pool with splash pad | High; Cathy flagged it as in-ground with splash pad | In-ground pages/gallery, not fiberglass brand sections |
 | `assets/images/gallery-06.webp` | Vinyl liner replacement in progress | High; client flagged as liner change | Liner replacement/process only |
 | `assets/images/pool-03.jpg` | Vinyl liner replacement in progress | High; same visible project as `gallery-06.webp` | Liner replacement/process only |
-| `assets/images/pool-06.jpg` | Finished in-ground vinyl liner pool | Medium-high visual evidence | Liner page or gallery |
+| `assets/images/pool-06.jpg` | Aquasport hybrid above-ground pool | High; Cathy flagged as Aquasport hybrid | Above-ground hybrid page/gallery |
 | `assets/images/pool-08.jpg` | Finished in-ground vinyl liner pool | Medium-high visual evidence | Liner page or gallery |
 | `assets/images/pool-10.jpg` | Vinyl liner installation/replacement | Medium-high visual evidence | Liner page or gallery |
-| `assets/images/gallery-05.webp` | Above-ground pool with deck | High visual evidence | Above-ground pages |
-| `assets/images/gallery-03.webp` / `pool-05.jpg` | Above-ground pool/deck area | High visual evidence | Above-ground pages/gallery |
-| `assets/images/pool-04.jpg` / `pool-12.jpg` | Above-ground pool | High visual evidence | Above-ground/service pages |
+| `assets/images/gallery-05.webp` | Hybrid Oasis with wraparound deck | High; Cathy flagged as Hybrid Oasis with 27–30 inch recess limit | Above-ground hybrid pages/gallery |
+| `assets/images/gallery-03.webp` / `pool-05.jpg` | Hybrid Oasis / above-ground deck area | High; Cathy flagged Oasis recess limit | Above-ground pages/gallery |
+| `assets/images/pool-04.jpg` | Above-ground pool | High visual evidence | Above-ground/service pages |
 | `assets/images/pool-07.jpg` | Above-ground round pool | High visual evidence | Above-ground pages/gallery |
-| `assets/images/gallery-02.webp` | In-ground vinyl-liner panel-wall construction | Medium visual evidence | Construction/gallery, not fiberglass |
-| `assets/images/gallery-01.webp` | In-ground construction, likely fiberglass shells | Medium visual evidence | Neutral construction unless client confirms |
-| `assets/images/pool-01.jpg` | In-ground pool project, material not fully confirmed | Medium-low | Neutral gallery caption |
-| `assets/images/pool-02.jpg` | Finished in-ground pool, likely vinyl liner | Medium | Neutral/liner-adjacent caption unless client confirms |
-| `assets/images/pool-09.jpg` | In-ground pool lighting/night scene | Low material confidence | Lighting/service/gallery only |
+| `assets/images/gallery-02.webp` | Steel wall in-ground construction | Medium visual evidence | Construction/gallery, not fiberglass |
+| `assets/images/gallery-01.webp` | In-ground construction, material not fully confirmed | Medium visual evidence | Neutral construction unless client confirms |
+| `assets/images/pool-01.jpg` | In-ground pool with splash pad under construction | High; Cathy flagged the finished project as in-ground with splash pad | In-ground/gallery |
+| `assets/images/pool-02.jpg` | Steel wall in-ground pool with deck | High; Cathy flagged this class of photos as steel wall in-ground | In-ground/gallery |
+| `assets/images/pool-12.jpg` | Aquasport hybrid above-ground pool | High; Cathy flagged as Aquasport hybrid | Above-ground hybrid pages/gallery |
+| `assets/images/pool-09.jpg` | Evening in-ground poolside scene | Low material confidence | Gallery only; do not use as LED-lighting proof |
 | `assets/images/pool-11.jpg` | Residential pool installation, material not confirmed | Low | Neutral gallery caption |
 
 ## Sources checked
@@ -71,5 +72,4 @@ Purpose: keep site copy, captions, gallery filters, and client photo placement f
 - River Pools: concrete uses rebar/concrete plus plaster/pebble/tile finish; vinyl liner pools use steel/polymer walls plus a vinyl surface; fiberglass uses factory-made fiberglass/resin/gelcoat shells. https://www.riverpoolsandspas.com/blog/inground-pool-comparison-infographic-vinyl-vs-concrete-vs-fiberglass-pool
 - Polaris/Fluidra: above-ground pools vary by frame/wall material, and above-ground liners are vinyl with overlap, beaded, and unibead types. https://www.polarispool.com/en/support/troubleshooting-faqs/buying-guides/types-of-above-ground-pools
 - GLI: in-ground liners are custom-made, available in 27/20 mil virgin vinyl, and use a bonding process for seams. https://www.glipoolproducts.com/inground-vinyl-liners/signature-series/
-- Pools by Genesis: Genesis positions these as fiberglass in-ground pools with model/color choices. https://poolsbygenesis.com/
 - Imagine Fiberglass: fiberglass designs include molded-in ledges, benches, swim lanes, and gelcoat color options. https://imaginefiberglasspools.com/designs/

--- a/faq.html
+++ b/faq.html
@@ -107,7 +107,7 @@
         </details>
         <details>
           <summary>What pool brands do you carry?</summary>
-          <p>We offer Imagine Fiberglass and Pools by Genesis for in-ground builds, plus Cardinal and Latham vinyl liners and above-ground systems like Genesis, Nakoma, and Discovery.</p>
+          <p>We offer Imagine Fiberglass for fiberglass in-ground builds, Cardinal and Latham for vinyl liner work, and above-ground systems such as Genesis, Nakoma, and Discovery when available.</p>
         </details>
         <details>
           <summary>Can I bring in water for testing?</summary>
@@ -223,7 +223,7 @@
           "name": "What pool brands do you carry?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "We offer Imagine Fiberglass and Pools by Genesis for in-ground builds, plus Cardinal and Latham vinyl liners and above-ground systems like Genesis, Nakoma, and Discovery."
+            "text": "We offer Imagine Fiberglass for fiberglass in-ground builds, Cardinal and Latham for vinyl liner work, and above-ground systems such as Genesis, Nakoma, and Discovery when available."
           }
         },
         {

--- a/gallery.html
+++ b/gallery.html
@@ -8,19 +8,19 @@
   <meta property="og:site_name" content="US-1 Pools">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Gallery | US-1 Pools">
-  <meta property="og:description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, construction, and lighting upgrades.">
+  <meta property="og:description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, and construction progress.">
   <meta property="og:url" content="https://www.us1pools.com/gallery">
-  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Gallery+%7C+US-1+Pools&amp;subtitle=Explore+US-1+Pools+projects+by+material+type%3A+fiberglass+shells%2C+vinyl+liner+replacements%2C+above-ground+installs%2C+construction%2C+and+lighting+upgrades.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Gallery+%7C+US-1+Pools&amp;subtitle=Explore+US-1+Pools+projects+by+material+type%3A+fiberglass+shells%2C+vinyl+liner+replacements%2C+above-ground+installs%2C+and+construction+progress.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Gallery | US-1 Pools social preview">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Gallery | US-1 Pools">
-  <meta name="twitter:description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, construction, and lighting upgrades.">
-  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Gallery+%7C+US-1+Pools&amp;subtitle=Explore+US-1+Pools+projects+by+material+type%3A+fiberglass+shells%2C+vinyl+liner+replacements%2C+above-ground+installs%2C+construction%2C+and+lighting+upgrades.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta name="twitter:description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, and construction progress.">
+  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Gallery+%7C+US-1+Pools&amp;subtitle=Explore+US-1+Pools+projects+by+material+type%3A+fiberglass+shells%2C+vinyl+liner+replacements%2C+above-ground+installs%2C+and+construction+progress.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
   <meta name="twitter:image:alt" content="Gallery | US-1 Pools social preview">
 
-  <meta name="description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, construction, and lighting upgrades." />
+  <meta name="description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, and construction progress." />
   <meta name="ai-content-declaration" content="human-authored, human-edited" />
   <link rel="alternate" type="text/markdown" href="https://www.us1pools.com/llms-full.txt" />
   <link rel="icon" type="image/png" href="assets/images/logo.png" />
@@ -82,7 +82,7 @@
       <div class="container">
         <p class="eyebrow">Gallery</p>
         <h1>Projects built for light, water, and long weekends.</h1>
-        <p>Explore recent builds, liner replacements, fiberglass shells, above-ground installs, and lighting upgrades across Franklin and surrounding counties. Filter by material type so the photos stay accurate.</p>
+        <p>Explore recent builds, liner replacements, fiberglass shells, above-ground installs, and construction progress across Franklin and surrounding counties. Filter by material type so the photos stay accurate.</p>
       </div>
     </section>
 
@@ -94,7 +94,6 @@
           <button class="filter-button" data-filter="vinyl-liner" aria-pressed="false">Vinyl liner</button>
           <button class="filter-button" data-filter="above-ground" aria-pressed="false">Above-ground</button>
           <button class="filter-button" data-filter="construction" aria-pressed="false">Construction</button>
-          <button class="filter-button" data-filter="lighting" aria-pressed="false">Lighting</button>
         </div>
 
         <div class="gallery-grid">
@@ -131,16 +130,16 @@
             <div class="image-caption">Finished vinyl liner pool</div>
           </article>
           <article class="image-card" data-category="above-ground new-build">
-            <img src="assets/images/pool-07.jpg" alt="Round above-ground pool installation" loading="lazy"  width="2500" height="1875" decoding="async"/>
-            <div class="image-caption">Round above-ground installation</div>
+            <img src="assets/images/pool-07.jpg" alt="Round above-ground pool with a retaining wall" loading="lazy"  width="2500" height="1875" decoding="async"/>
+            <div class="image-caption">Above-ground pool with retaining wall</div>
           </article>
           <article class="image-card" data-category="vinyl-liner in-ground">
             <img src="assets/images/pool-08.jpg" alt="Finished vinyl liner pool with patterned interior" loading="lazy"  width="2500" height="1875" decoding="async"/>
             <div class="image-caption">Finished vinyl liner pool</div>
           </article>
-          <article class="image-card" data-category="in-ground lighting">
-            <img src="assets/images/pool-09.jpg" alt="In-ground pool with LED lighting at night" loading="lazy"  width="836" height="627" decoding="async"/>
-            <div class="image-caption">LED lighting for night swims</div>
+          <article class="image-card" data-category="in-ground">
+            <img src="assets/images/pool-09.jpg" alt="In-ground pool and patio at night with landscape lighting" loading="lazy"  width="836" height="627" decoding="async"/>
+            <div class="image-caption">Evening poolside setting</div>
           </article>
           <article class="image-card" data-category="vinyl-liner liner-replacement construction">
             <img src="assets/images/pool-10.jpg" alt="Vinyl liner pool interior during replacement" loading="lazy"  width="2500" height="1875" decoding="async"/>

--- a/gallery.html
+++ b/gallery.html
@@ -8,19 +8,19 @@
   <meta property="og:site_name" content="US-1 Pools">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Gallery | US-1 Pools">
-  <meta property="og:description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, and construction progress.">
+  <meta property="og:description" content="Explore US-1 Pools projects by material type: steel wall in-ground builds, vinyl liner replacements, above-ground installs, hybrid pools, and construction progress.">
   <meta property="og:url" content="https://www.us1pools.com/gallery">
-  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Gallery+%7C+US-1+Pools&amp;subtitle=Explore+US-1+Pools+projects+by+material+type%3A+fiberglass+shells%2C+vinyl+liner+replacements%2C+above-ground+installs%2C+and+construction+progress.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Gallery+%7C+US-1+Pools&amp;subtitle=Explore+US-1+Pools+projects+by+material+type%3A+steel+wall+in-ground+builds%2C+vinyl+liner+replacements%2C+above-ground+installs%2C+hybrid+pools%2C+and+construction+progress.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Gallery | US-1 Pools social preview">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Gallery | US-1 Pools">
-  <meta name="twitter:description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, and construction progress.">
-  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Gallery+%7C+US-1+Pools&amp;subtitle=Explore+US-1+Pools+projects+by+material+type%3A+fiberglass+shells%2C+vinyl+liner+replacements%2C+above-ground+installs%2C+and+construction+progress.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta name="twitter:description" content="Explore US-1 Pools projects by material type: steel wall in-ground builds, vinyl liner replacements, above-ground installs, hybrid pools, and construction progress.">
+  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Gallery+%7C+US-1+Pools&amp;subtitle=Explore+US-1+Pools+projects+by+material+type%3A+steel+wall+in-ground+builds%2C+vinyl+liner+replacements%2C+above-ground+installs%2C+hybrid+pools%2C+and+construction+progress.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
   <meta name="twitter:image:alt" content="Gallery | US-1 Pools social preview">
 
-  <meta name="description" content="Explore US-1 Pools projects by material type: fiberglass shells, vinyl liner replacements, above-ground installs, and construction progress." />
+  <meta name="description" content="Explore US-1 Pools projects by material type: steel wall in-ground builds, vinyl liner replacements, above-ground installs, hybrid pools, and construction progress." />
   <meta name="ai-content-declaration" content="human-authored, human-edited" />
   <link rel="alternate" type="text/markdown" href="https://www.us1pools.com/llms-full.txt" />
   <link rel="icon" type="image/png" href="assets/images/logo.png" />
@@ -82,7 +82,7 @@
       <div class="container">
         <p class="eyebrow">Gallery</p>
         <h1>Projects built for light, water, and long weekends.</h1>
-        <p>Explore recent builds, liner replacements, fiberglass shells, above-ground installs, and construction progress across Franklin and surrounding counties. Filter by material type so the photos stay accurate.</p>
+        <p>Explore recent builds, liner replacements, steel wall in-ground pools, above-ground installs, hybrid pools, and construction progress across Franklin and surrounding counties. Filter by material type so the photos stay accurate.</p>
       </div>
     </section>
 
@@ -90,28 +90,29 @@
       <div class="container">
         <div class="filter-bar" aria-label="Gallery filters">
           <button class="filter-button active" data-filter="all" aria-pressed="true">All</button>
-          <button class="filter-button" data-filter="fiberglass" aria-pressed="false">Fiberglass</button>
+          <button class="filter-button" data-filter="in-ground" aria-pressed="false">In-ground</button>
           <button class="filter-button" data-filter="vinyl-liner" aria-pressed="false">Vinyl liner</button>
           <button class="filter-button" data-filter="above-ground" aria-pressed="false">Above-ground</button>
+          <button class="filter-button" data-filter="hybrid" aria-pressed="false">Hybrid</button>
           <button class="filter-button" data-filter="construction" aria-pressed="false">Construction</button>
         </div>
 
         <div class="gallery-grid">
-          <article class="image-card" data-category="fiberglass in-ground new-build">
-            <img src="assets/images/gallery-04.webp" alt="Fiberglass in-ground pool shell with finished concrete deck" loading="lazy"  width="2500" height="1875" decoding="async"/>
-            <div class="image-caption">Fiberglass in-ground shell</div>
+          <article class="image-card" data-category="in-ground new-build splash-pad">
+            <img src="assets/images/gallery-04.webp" alt="In-ground pool with splash pad and finished concrete deck" loading="lazy"  width="2500" height="1875" decoding="async"/>
+            <div class="image-caption">In-ground pool with splash pad</div>
           </article>
-          <article class="image-card" data-category="vinyl-liner in-ground new-build">
-            <img src="assets/images/customer-pool-sunset.webp" alt="Finished in-ground vinyl liner pool at sunset" loading="lazy"  width="1800" height="1350" decoding="async"/>
-            <div class="image-caption">Finished vinyl liner pool at sunset</div>
-          </article>
-          <article class="image-card" data-category="in-ground construction">
-            <img src="assets/images/pool-01.jpg" alt="In-ground pool project under construction" loading="lazy"  width="2500" height="1875" decoding="async"/>
-            <div class="image-caption">In-ground pool project</div>
+          <article class="image-card" data-category="in-ground steel-wall new-build">
+            <img src="assets/images/customer-pool-sunset.webp" alt="Steel wall in-ground pool at sunset" loading="lazy"  width="1800" height="1350" decoding="async"/>
+            <div class="image-caption">Steel wall in-ground pool at sunset</div>
           </article>
           <article class="image-card" data-category="in-ground construction">
-            <img src="assets/images/pool-02.jpg" alt="Finished in-ground pool with deck" loading="lazy"  width="1440" height="700" decoding="async"/>
-            <div class="image-caption">Finished in-ground pool with deck</div>
+            <img src="assets/images/pool-01.jpg" alt="In-ground pool with splash pad under construction" loading="lazy"  width="2500" height="1875" decoding="async"/>
+            <div class="image-caption">In-ground pool with splash pad under construction</div>
+          </article>
+          <article class="image-card" data-category="in-ground construction">
+            <img src="assets/images/pool-02.jpg" alt="Steel wall in-ground pool with deck" loading="lazy"  width="1440" height="700" decoding="async"/>
+            <div class="image-caption">Steel wall in-ground pool with deck</div>
           </article>
           <article class="image-card" data-category="vinyl-liner liner-replacement construction">
             <img src="assets/images/pool-03.jpg" alt="Vinyl liner replacement in progress" loading="lazy"  width="2500" height="1875" decoding="async"/>
@@ -121,13 +122,13 @@
             <img src="assets/images/pool-04.jpg" alt="Above-ground pool installation with equipment system" loading="lazy"  width="836" height="627" decoding="async"/>
             <div class="image-caption">Above-ground equipment setup</div>
           </article>
-          <article class="image-card" data-category="above-ground construction">
-            <img src="assets/images/pool-05.jpg" alt="Above-ground pool deck and patio project" loading="lazy"  width="2500" height="3333" decoding="async"/>
-            <div class="image-caption">Above-ground deck and patio project</div>
+          <article class="image-card" data-category="above-ground hybrid">
+            <img src="assets/images/pool-05.jpg" alt="Hybrid Oasis above-ground pool, partially recessed" loading="lazy"  width="2500" height="3333" decoding="async"/>
+            <div class="image-caption">Hybrid Oasis — 27–30 in. max recess</div>
           </article>
-          <article class="image-card" data-category="vinyl-liner in-ground">
-            <img src="assets/images/pool-06.jpg" alt="Finished in-ground vinyl liner pool with blue patterned liner" loading="lazy"  width="2500" height="1875" decoding="async"/>
-            <div class="image-caption">Finished vinyl liner pool</div>
+          <article class="image-card" data-category="above-ground hybrid new-build">
+            <img src="assets/images/pool-06.jpg" alt="Aquasport hybrid above-ground pool with blue liner" loading="lazy"  width="2500" height="1875" decoding="async"/>
+            <div class="image-caption">Aquasport hybrid above-ground pool</div>
           </article>
           <article class="image-card" data-category="above-ground new-build">
             <img src="assets/images/pool-07.jpg" alt="Round above-ground pool with a retaining wall" loading="lazy"  width="2500" height="1875" decoding="async"/>
@@ -149,9 +150,9 @@
             <img src="assets/images/pool-11.jpg" alt="Residential pool installation project" loading="lazy"  width="2500" height="1875" decoding="async"/>
             <div class="image-caption">Residential pool installation</div>
           </article>
-          <article class="image-card" data-category="above-ground">
-            <img src="assets/images/pool-12.jpg" alt="Finished above-ground pool with stone surround" loading="lazy"  width="836" height="627" decoding="async"/>
-            <div class="image-caption">Finished above-ground pool</div>
+          <article class="image-card" data-category="above-ground hybrid new-build">
+            <img src="assets/images/pool-12.jpg" alt="Aquasport hybrid above-ground pool with stone surround" loading="lazy"  width="836" height="627" decoding="async"/>
+            <div class="image-caption">Aquasport hybrid above-ground pool</div>
           </article>
         </div>
       </div>

--- a/hot-tubs.html
+++ b/hot-tubs.html
@@ -94,17 +94,17 @@
     <section class="section reveal">
       <div class="container content-grid">
         <div>
-          <p class="eyebrow">Spa care support</p>
-          <h2>Water-care products for the spa you choose.</h2>
-          <p class="section-sub">Choose a dedicated spa or integrated setup, then rely on the showroom for start-up water balancing, filters, chemicals, and care products.</p>
+          <p class="eyebrow">Water-care support</p>
+          <h2>Showroom guidance for clean, balanced water.</h2>
+          <p class="section-sub">Choose a dedicated spa or integrated setup, then rely on the team for start-up water balancing guidance, maintenance support, and the right care routine.</p>
           <div class="model-list">
             <span class="model-chip">Tranquility</span>
             <span class="model-chip">Garden Leisure</span>
           </div>
         </div>
         <div class="image-card">
-          <img src="assets/images/hero-secondary.webp" alt="Spa care and water-care products in the US-1 Pools showroom" loading="lazy"  width="2500" height="1875" decoding="async"/>
-          <span class="image-caption">Showroom spa care products</span>
+          <img src="assets/images/hero-secondary.webp" alt="Pool chemicals, nets, and cleaning accessories in the US-1 Pools showroom" loading="lazy"  width="2500" height="1875" decoding="async"/>
+          <span class="image-caption">Showroom water-care supplies</span>
         </div>
       </div>
     </section>

--- a/in-ground.html
+++ b/in-ground.html
@@ -95,11 +95,10 @@
       <div class="container content-grid">
         <div>
           <p class="eyebrow">Fiberglass shells</p>
-          <h2>Imagine Fiberglass + Pools by Genesis.</h2>
-          <p class="section-sub">These fiberglass pool brands use factory-molded shells with smooth gelcoat surfaces and integrated ledges, benches, steps, and swim zones.</p>
+          <h2>Imagine Fiberglass shells.</h2>
+          <p class="section-sub">Imagine Fiberglass uses factory-molded shells with smooth gelcoat surfaces and integrated ledges, benches, steps, and swim zones.</p>
           <div class="model-list">
             <span class="model-chip">Imagine Fiberglass</span>
-            <span class="model-chip">Pools by Genesis</span>
           </div>
         </div>
         <div class="image-card">
@@ -143,14 +142,14 @@
               <p>Alternative sanitation options for softer water.</p>
             </div>
             <div class="list-card">
-              <h3>Lighting</h3>
-              <p>LED and specialty lighting for night swims.</p>
+              <h3>Upgrade planning</h3>
+              <p>Equipment options are planned around how you actually use the pool.</p>
             </div>
           </div>
         </div>
         <div class="image-card">
-          <img src="assets/images/pool-09.jpg" alt="In-ground pool with LED lighting at night" loading="lazy"  width="836" height="627" decoding="async"/>
-          <span class="image-caption">LED lighting for night swims</span>
+          <img src="assets/images/pool-09.jpg" alt="In-ground pool and patio at night with landscape lighting" loading="lazy"  width="836" height="627" decoding="async"/>
+          <span class="image-caption">Evening poolside setting</span>
         </div>
       </div>
     </section>

--- a/in-ground.html
+++ b/in-ground.html
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Fiberglass &amp; Vinyl Liner In-Ground Pools | US-1 Pools</title>
+  <title>In-Ground Pools | US-1 Pools</title>
   <link rel="canonical" href="https://www.us1pools.com/in-ground">
   <meta property="og:site_name" content="US-1 Pools">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Fiberglass &amp; Vinyl Liner In-Ground Pools | US-1 Pools">
-  <meta property="og:description" content="Fiberglass in-ground shells and vinyl liner options from US-1 Pools, clearly separated by material type so customers can compare the right build or replacement path.">
+  <meta property="og:title" content="In-Ground Pools | US-1 Pools">
+  <meta property="og:description" content="Steel wall, vinyl liner, and fiberglass in-ground pool options from US-1 Pools, clearly separated by material type so customers can compare the right build or replacement path.">
   <meta property="og:url" content="https://www.us1pools.com/in-ground">
-  <meta property="og:image" content="https://www.us1pools.com/api/og?title=Fiberglass+%26+Vinyl+Liner+In-Ground+Pools+%7C+US-1+Pools&amp;subtitle=Fiberglass+in-ground+shells+and+vinyl+liner+options+from+US-1+Pools%2C+clearly+separated+by+material+type+so+customers+can+compare+the+right+build+or+replacement+path.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
+  <meta property="og:image" content="https://www.us1pools.com/api/og?title=In-Ground%20Pools%20%7C%20US-1%20Pools&amp;subtitle=Steel%20wall%2C%20vinyl%20liner%2C%20and%20fiberglass%20in-ground%20pool%20options%20from%20US-1%20Pools%2C%20clearly%20separated%20by%20material%20type%20so%20customers%20can%20compare%20the%20right%20build%20or%20replacement%20path.&amp;eyebrow=Sales%20%E2%80%A2%20service%20%E2%80%A2%20installation">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
-  <meta property="og:image:alt" content="Fiberglass &amp; Vinyl Liner In-Ground Pools | US-1 Pools social preview">
+  <meta property="og:image:alt" content="In-Ground Pools | US-1 Pools social preview">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Fiberglass &amp; Vinyl Liner In-Ground Pools | US-1 Pools">
-  <meta name="twitter:description" content="Fiberglass in-ground shells and vinyl liner options from US-1 Pools, clearly separated by material type so customers can compare the right build or replacement path.">
-  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=Fiberglass+%26+Vinyl+Liner+In-Ground+Pools+%7C+US-1+Pools&amp;subtitle=Fiberglass+in-ground+shells+and+vinyl+liner+options+from+US-1+Pools%2C+clearly+separated+by+material+type+so+customers+can+compare+the+right+build+or+replacement+path.&amp;eyebrow=Sales+%E2%80%A2+service+%E2%80%A2+installation">
-  <meta name="twitter:image:alt" content="Fiberglass &amp; Vinyl Liner In-Ground Pools | US-1 Pools social preview">
+  <meta name="twitter:title" content="In-Ground Pools | US-1 Pools">
+  <meta name="twitter:description" content="Steel wall, vinyl liner, and fiberglass in-ground pool options from US-1 Pools, clearly separated by material type so customers can compare the right build or replacement path.">
+  <meta name="twitter:image" content="https://www.us1pools.com/api/og?title=In-Ground%20Pools%20%7C%20US-1%20Pools&amp;subtitle=Steel%20wall%2C%20vinyl%20liner%2C%20and%20fiberglass%20in-ground%20pool%20options%20from%20US-1%20Pools%2C%20clearly%20separated%20by%20material%20type%20so%20customers%20can%20compare%20the%20right%20build%20or%20replacement%20path.&amp;eyebrow=Sales%20%E2%80%A2%20service%20%E2%80%A2%20installation">
+  <meta name="twitter:image:alt" content="In-Ground Pools | US-1 Pools social preview">
 
-  <meta name="description" content="Fiberglass in-ground shells and vinyl liner options from US-1 Pools, clearly separated by material type so customers can compare the right build or replacement path." />
+  <meta name="description" content="Steel wall, vinyl liner, and fiberglass in-ground pool options from US-1 Pools, clearly separated by material type so customers can compare the right build or replacement path." />
   <meta name="ai-content-declaration" content="human-authored, human-edited" />
   <link rel="alternate" type="text/markdown" href="https://www.us1pools.com/llms-full.txt" />
   <link rel="icon" type="image/png" href="assets/images/logo.png" />
@@ -80,13 +80,13 @@
   <main id="main">
     <section class="page-hero">
       <div class="container">
-        <p class="eyebrow">In-Ground Materials</p>
-        <h1>Fiberglass shells and vinyl liner pools, clearly separated.</h1>
-        <p>US-1 Pools helps customers compare fiberglass in-ground shells, vinyl liner replacements, and the equipment upgrades that support both pool types.</p>
+        <p class="eyebrow">In-Ground Pools</p>
+        <h1>Steel wall, vinyl liner, and fiberglass options — clearly separated.</h1>
+        <p>US-1 Pools helps customers compare steel wall in-ground builds, vinyl liner replacements, fiberglass shell options, and the equipment that supports each pool type.</p>
         <div class="page-meta">
-          <span class="meta-chip">Fiberglass shells</span>
+          <span class="meta-chip">Steel wall</span>
           <span class="meta-chip">Vinyl liners</span>
-          <span class="meta-chip">Pentair systems</span>
+          <span class="meta-chip">Imagine Fiberglass</span>
         </div>
       </div>
     </section>
@@ -94,16 +94,18 @@
     <section class="section reveal">
       <div class="container content-grid">
         <div>
-          <p class="eyebrow">Fiberglass shells</p>
-          <h2>Imagine Fiberglass shells.</h2>
-          <p class="section-sub">Imagine Fiberglass uses factory-molded shells with smooth gelcoat surfaces and integrated ledges, benches, steps, and swim zones.</p>
+          <p class="eyebrow">In-ground planning</p>
+          <h2>Steel wall, vinyl liner, and fiberglass options.</h2>
+          <p class="section-sub">We separate steel wall in-ground builds, vinyl liner replacements, and Imagine Fiberglass shell options during the quote. Features like splash pads are planned around the site.</p>
           <div class="model-list">
+            <span class="model-chip">Steel wall</span>
+            <span class="model-chip">Vinyl liner</span>
             <span class="model-chip">Imagine Fiberglass</span>
           </div>
         </div>
         <div class="image-card">
-          <img src="assets/images/gallery-04.webp" alt="Fiberglass in-ground pool shell with finished concrete deck" loading="lazy"  width="2500" height="1875" decoding="async"/>
-          <span class="image-caption">Fiberglass shell installation</span>
+          <img src="assets/images/gallery-04.webp" alt="In-ground pool with splash pad and finished concrete deck" loading="lazy"  width="2500" height="1875" decoding="async"/>
+          <span class="image-caption">In-ground pool with splash pad</span>
         </div>
       </div>
     </section>
@@ -120,8 +122,8 @@
           </div>
         </div>
         <div class="image-card">
-          <img src="assets/images/customer-pool-sunset.webp" alt="Finished in-ground vinyl liner pool at sunset" loading="lazy"  width="1800" height="1350" decoding="async"/>
-          <span class="image-caption">Finished vinyl liner pool</span>
+          <img src="assets/images/customer-pool-sunset.webp" alt="Steel wall in-ground pool at sunset" loading="lazy"  width="1800" height="1350" decoding="async"/>
+          <span class="image-caption">Steel wall in-ground pool at sunset</span>
         </div>
       </div>
     </section>
@@ -223,8 +225,8 @@
     {
           "@context": "https://schema.org",
           "@type": "Product",
-          "name": "Fiberglass and Vinyl Liner In-Ground Pool Options",
-          "description": "Fiberglass in-ground shell guidance, vinyl liner replacement, equipment upgrades, and site planning in Franklinton, NC and surrounding counties.",
+          "name": "In-Ground Pool Options",
+          "description": "Steel wall in-ground planning, fiberglass shell guidance, vinyl liner replacement, equipment upgrades, and site planning in Franklinton, NC and surrounding counties.",
           "url": "https://www.us1pools.com/in-ground.html",
           "dateModified": "2026-03-14",
           "image": "https://www.us1pools.com/assets/images/logo.png",

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
         <span class="partner-item">Latham Pools</span>
         <span class="partner-item">GLI Pool Products</span>
         <span class="partner-item">Imagine Fiberglass</span>
-        <span class="partner-item">Pools by Genesis</span>
+        <span class="partner-item">Genesis</span>
         <span class="partner-item">Tranquility Spas</span>
         <span class="partner-item">Garden Leisure</span>
         <span class="partner-item">Maytronics Dolphin</span>
@@ -160,7 +160,7 @@
         <span class="partner-item">Latham Pools</span>
         <span class="partner-item">GLI Pool Products</span>
         <span class="partner-item">Imagine Fiberglass</span>
-        <span class="partner-item">Pools by Genesis</span>
+        <span class="partner-item">Genesis</span>
         <span class="partner-item">Tranquility Spas</span>
         <span class="partner-item">Garden Leisure</span>
         <span class="partner-item">Maytronics Dolphin</span>
@@ -186,7 +186,7 @@
 </svg>
             </div>
             <h3>Above Ground</h3>
-            <p>Vinyl liner and resin systems with optional deck packages.</p>
+            <p>Vinyl liner and resin systems with optional deck packages; current model availability is confirmed before quoting.</p>
             <div class="model-list">
               <span class="model-chip">Genesis</span>
               <span class="model-chip">Nakoma</span>
@@ -207,10 +207,9 @@
 		c-6,0-6,3-12,3s-6-3-12-3s-6,3-12,3s-6-3-12-3c-6,0-6,3-12,3c-6,0-6-3-12-3s-6,3-12,3c-6,0-6-3-12-3V66z" clip-rule="evenodd"/></svg>
             </div>
             <h3>Fiberglass In-Ground</h3>
-            <p>Factory-molded fiberglass shells with modern finishes and smart systems.</p>
+            <p>Factory-molded Imagine Fiberglass shells with modern finishes and smart systems.</p>
             <div class="model-list">
               <span class="model-chip">Imagine Fiberglass</span>
-              <span class="model-chip">Pools by Genesis</span>
             </div>
             <a class="btn btn-ghost" href="in-ground.html">Explore In-Ground</a>
           </article>

--- a/index.html
+++ b/index.html
@@ -117,12 +117,12 @@
         </div>
         <div class="hero-media" aria-hidden="true">
           <figure class="image-card">
-            <img src="assets/images/customer-pool-sunset.webp" alt="Finished in-ground vinyl liner pool at sunset installed by US-1 Pools" loading="eager" fetchpriority="high" width="1800" height="1350" />
-            <span class="image-caption">Finished vinyl liner pool at sunset</span>
+            <img src="assets/images/customer-pool-sunset.webp" alt="Steel wall in-ground pool at sunset installed by US-1 Pools" loading="eager" fetchpriority="high" width="1800" height="1350" />
+            <span class="image-caption">Steel wall in-ground pool at sunset</span>
           </figure>
           <figure class="image-card">
-            <img src="assets/images/gallery-05.webp" alt="Above-ground pool with wraparound deck and landscaped backyard installed by US-1 Pools" loading="lazy" width="2500" height="1215" decoding="async" />
-            <span class="image-caption">Above-ground pool with deck package</span>
+            <img src="assets/images/gallery-05.webp" alt="Hybrid Oasis above-ground pool with wraparound deck installed by US-1 Pools" loading="lazy" width="2500" height="1215" decoding="async" />
+            <span class="image-caption">Hybrid Oasis with deck package</span>
           </figure>
         </div>
       </div>
@@ -186,7 +186,7 @@
 </svg>
             </div>
             <h3>Above Ground</h3>
-            <p>Vinyl liner and resin systems with optional deck packages; current model availability is confirmed before quoting.</p>
+            <p>Vinyl liner, resin, and hybrid options with optional deck packages; current model availability is confirmed before quoting.</p>
             <div class="model-list">
               <span class="model-chip">Genesis</span>
               <span class="model-chip">Nakoma</span>
@@ -206,8 +206,8 @@
 		c-6,0-6-3-12-3V78z M0,66c6,0,6,3,12,3c6,0,6-3,12-3s6,3,12,3c6,0,6-3,12-3c6,0,6,3,12,3s6-3,12-3s6,3,12,3s6-3,12-3v3
 		c-6,0-6,3-12,3s-6-3-12-3s-6,3-12,3s-6-3-12-3c-6,0-6,3-12,3c-6,0-6-3-12-3s-6,3-12,3c-6,0-6-3-12-3V66z" clip-rule="evenodd"/></svg>
             </div>
-            <h3>Fiberglass In-Ground</h3>
-            <p>Factory-molded Imagine Fiberglass shells with modern finishes and smart systems.</p>
+            <h3>In-Ground Pools</h3>
+            <p>Steel wall, vinyl liner, and Imagine Fiberglass options with clear material guidance.</p>
             <div class="model-list">
               <span class="model-chip">Imagine Fiberglass</span>
             </div>
@@ -603,7 +603,7 @@
           { "@type": "OfferCatalog", "name": "Pool Installation", "itemListElement": [
             { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Above-Ground Pool Installation" } },
             { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "In-Ground Pool Installation" } },
-            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Fiberglass Pool Installation" } },
+            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "In-Ground Pool Installation" } },
             { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Hot Tub & Swim Spa Installation" } }
           ]},
           { "@type": "OfferCatalog", "name": "Pool Maintenance & Repair", "itemListElement": [

--- a/liners.html
+++ b/liners.html
@@ -104,11 +104,11 @@
             </div>
             <div class="list-card">
               <h3>In-ground liners</h3>
-              <p>Custom-measured to your pool dimensions. 20-mil standard or 28-mil heavy-duty with wall foam backing.</p>
+              <p>Custom-measured to your pool dimensions. 20-mil standard or 28-mil heavy-duty options. Wall foam can be requested as an add-on.</p>
             </div>
             <div class="list-card">
-              <h3>Safety covers</h3>
-              <p>GLI also makes mesh and solid safety covers for winter protection — custom-fit to any pool shape.</p>
+              <h3>In-ground mesh safety covers</h3>
+              <p>GLI in-ground mesh safety covers are custom-fit for winter protection. Solid cover options are available when appropriate.</p>
             </div>
           </div>
         </div>
@@ -137,8 +137,8 @@
           </div>
         </div>
         <div class="image-card">
-          <img src="assets/images/pool-06.jpg" alt="Finished in-ground vinyl liner pool with blue patterned liner" loading="lazy"  width="2500" height="1875" decoding="async"/>
-          <span class="image-caption">Finished vinyl liner pool</span>
+          <img src="assets/images/customer-pool-sunset.webp" alt="Steel wall in-ground pool at sunset" loading="lazy"  width="1800" height="1350" decoding="async"/>
+          <span class="image-caption">Steel wall in-ground pool at sunset</span>
         </div>
       </div>
     </section>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # US-1 Pools — Full Site Content
 
-> Plain-text corpus of every public page on us1pools.com. Generated for AI crawlers and language models. Last build: 2026-05-11
+> Plain-text corpus of every public page on us1pools.com. Generated for AI crawlers and language models. Last build: 2026-05-14
 
 ## Home
 Source: https://www.us1pools.com/
@@ -71,7 +71,7 @@ Authorized dealer for
 Latham Pools
 GLI Pool Products
 Imagine Fiberglass
-Pools by Genesis
+Genesis
 Tranquility Spas
 Garden Leisure
 Maytronics Dolphin
@@ -79,7 +79,7 @@ Oxygen Pools
 Latham Pools
 GLI Pool Products
 Imagine Fiberglass
-Pools by Genesis
+Genesis
 Tranquility Spas
 Garden Leisure
 Maytronics Dolphin
@@ -103,7 +103,7 @@ Above-ground systems, fiberglass in-ground shells, vinyl liner replacements, and
 
 
 Above Ground
-Vinyl liner and resin systems with optional deck packages.
+Vinyl liner and resin systems with optional deck packages; current model availability is confirmed before quoting.
 
 Genesis
 Nakoma
@@ -116,10 +116,9 @@ Explore Above Ground
 
 
 Fiberglass In-Ground
-Factory-molded fiberglass shells with modern finishes and smart systems.
+Factory-molded Imagine Fiberglass shells with modern finishes and smart systems.
 
 Imagine Fiberglass
-Pools by Genesis
 
 Explore In-Ground
 
@@ -461,8 +460,8 @@ Hot Tubs
 
 
 Above Ground
-Fast installs with steel, resin, or hybrid wall systems.
-Above-ground pools use visible wall and frame systems with a replaceable vinyl liner inside. We help match the structure, liner style, and deck package to your yard.
+Fast installs with steel and resin wall systems.
+Above-ground pools use visible wall and frame systems with a replaceable vinyl liner inside. Model availability changes, so we match the structure, liner style, and deck package to your yard during the quote.
 
 Genesis
 Nakoma
@@ -482,10 +481,9 @@ Above-ground pool with deck package
 
 Fiberglass In-Ground
 Factory-molded fiberglass shells with modern finishes.
-Choose from Imagine Fiberglass and Pools by Genesis shells, with molded steps, benches, ledges, and equipment packages from Pentair dealers.
+Choose Imagine Fiberglass shells with molded steps, benches, ledges, and equipment packages from Pentair dealers.
 
 Imagine Fiberglass
-Pools by Genesis
 
 Explore in-ground
 
@@ -510,7 +508,7 @@ Explore Spas
 
 
 
-Showroom spa care support
+Showroom water-care supplies
 
 
 
@@ -557,11 +555,11 @@ Source: https://www.us1pools.com/above-ground.html
 
 Above Ground
 Fast installs with clean, modern profiles.
-US-1 Pools installs above-ground pools with vinyl liner, resin, hybrid, and steel options plus decks, stairs, and start-up service.
+US-1 Pools installs above-ground pools with vinyl liner, resin, and steel options plus decks, stairs, and start-up service.
 
 Vinyl liner
 Resin systems
-Hybrid + steel
+Steel options
 
 
 
@@ -570,8 +568,8 @@ Hybrid + steel
 
 
 Resin pools
-Genesis, Nakoma, and Discovery.
-Resin options hold up in humid summers and deliver clean lines with minimal upkeep. Project photos here show representative above-ground installs; exact wall materials are confirmed before quoting.
+Genesis, Nakoma, Discovery, and current options.
+Resin options hold up in humid summers and deliver clean lines with minimal upkeep. Some model lines change over time, so we confirm current availability before quoting.
 
 Genesis
 Nakoma
@@ -588,18 +586,18 @@ Representative above-ground deck package
 
 
 
-Hybrid pools
-AquaSport, Oasis, and Ultimate.
-Hybrid construction blends strength and style while keeping installs efficient. We confirm the specific frame and wall package during the quote.
+Yard-fit planning
+Above-ground installs can adapt to sloped yards.
+Some installs need retaining-wall or deck planning so the pool sits cleanly in the yard. We confirm the exact model, wall package, and site prep during the quote.
 
-AquaSport
-Oasis
-Ultimate
-
-
+Retaining walls
+Deck planning
+Site prep
 
 
-Representative round above-ground install
+
+
+Above-ground pool with retaining wall
 
 
 
@@ -660,11 +658,10 @@ Pentair systems
 
 
 Fiberglass shells
-Imagine Fiberglass + Pools by Genesis.
-These fiberglass pool brands use factory-molded shells with smooth gelcoat surfaces and integrated ledges, benches, steps, and swim zones.
+Imagine Fiberglass shells.
+Imagine Fiberglass uses factory-molded shells with smooth gelcoat surfaces and integrated ledges, benches, steps, and swim zones.
 
 Imagine Fiberglass
-Pools by Genesis
 
 
 
@@ -708,14 +705,14 @@ Salt or oxygen
 Alternative sanitation options for softer water.
 
 
-Lighting
-LED and specialty lighting for night swims.
+Upgrade planning
+Equipment options are planned around how you actually use the pool.
 
 
 
 
 
-LED lighting for night swims
+Evening poolside setting
 
 
 
@@ -754,9 +751,9 @@ Service support
 
 
 
-Spa care support
-Water-care products for the spa you choose.
-Choose a dedicated spa or integrated setup, then rely on the showroom for start-up water balancing, filters, chemicals, and care products.
+Water-care support
+Showroom guidance for clean, balanced water.
+Choose a dedicated spa or integrated setup, then rely on the team for start-up water balancing guidance, maintenance support, and the right care routine.
 
 Tranquility
 Garden Leisure
@@ -764,7 +761,7 @@ Garden Leisure
 
 
 
-Showroom spa care products
+Showroom water-care supplies
 
 
 
@@ -1036,7 +1033,7 @@ Source: https://www.us1pools.com/gallery.html
 
 Gallery
 Projects built for light, water, and long weekends.
-Explore recent builds, liner replacements, fiberglass shells, above-ground installs, and lighting upgrades across Franklin and surrounding counties. Filter by material type so the photos stay accurate.
+Explore recent builds, liner replacements, fiberglass shells, above-ground installs, and construction progress across Franklin and surrounding counties. Filter by material type so the photos stay accurate.
 
 
 
@@ -1048,7 +1045,6 @@ Fiberglass
 Vinyl liner
 Above-ground
 Construction
-Lighting
 
 
 
@@ -1086,7 +1082,7 @@ Finished vinyl liner pool
 
 
 
-Round above-ground installation
+Above-ground pool with retaining wall
 
 
 
@@ -1094,7 +1090,7 @@ Finished vinyl liner pool
 
 
 
-LED lighting for night swims
+Evening poolside setting
 
 
 
@@ -1541,7 +1537,7 @@ Yes. We provide seasonal openings and closings, including water balancing and eq
 
 
 What pool brands do you carry?
-We offer Imagine Fiberglass and Pools by Genesis for in-ground builds, plus Cardinal and Latham vinyl liners and above-ground systems like Genesis, Nakoma, and Discovery.
+We offer Imagine Fiberglass for fiberglass in-ground builds, Cardinal and Latham for vinyl liner work, and above-ground systems such as Genesis, Nakoma, and Discovery when available.
 
 
 Can I bring in water for testing?

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -37,11 +37,11 @@ Sales, installs, maintenance, and retail equipment in one place.
 
 
 
-Finished vinyl liner pool at sunset
+Steel wall in-ground pool at sunset
 
 
 
-Above-ground pool with deck package
+Hybrid Oasis with deck package
 
 
 
@@ -103,7 +103,7 @@ Above-ground systems, fiberglass in-ground shells, vinyl liner replacements, and
 
 
 Above Ground
-Vinyl liner and resin systems with optional deck packages; current model availability is confirmed before quoting.
+Vinyl liner, resin, and hybrid options with optional deck packages; current model availability is confirmed before quoting.
 
 Genesis
 Nakoma
@@ -115,8 +115,8 @@ Explore Above Ground
 
 
 
-Fiberglass In-Ground
-Factory-molded Imagine Fiberglass shells with modern finishes and smart systems.
+In-Ground Pools
+Steel wall, vinyl liner, and Imagine Fiberglass options with clear material guidance.
 
 Imagine Fiberglass
 
@@ -446,10 +446,10 @@ Source: https://www.us1pools.com/pools.html
 
 Pools & Spas
 Find the right pool for how you live outside.
-US-1 Pools separates the choice clearly: above-ground systems, fiberglass in-ground shells, vinyl liner replacement, and hot tubs or swim spas.
+US-1 Pools separates the choice clearly: above-ground systems, in-ground steel wall, vinyl liner and fiberglass options, and hot tubs or swim spas.
 
 Above Ground
-Fiberglass Shells
+In-Ground
 Vinyl Liners
 Hot Tubs
 
@@ -460,8 +460,8 @@ Hot Tubs
 
 
 Above Ground
-Fast installs with steel and resin wall systems.
-Above-ground pools use visible wall and frame systems with a replaceable vinyl liner inside. Model availability changes, so we match the structure, liner style, and deck package to your yard during the quote.
+Fast installs with steel, resin, and hybrid options.
+Above-ground pools use visible wall and frame systems with a replaceable vinyl liner inside. Model availability changes, so we match the structure, liner style, Aquasport or Oasis hybrid option, and deck package to your yard during the quote.
 
 Genesis
 Nakoma
@@ -471,7 +471,7 @@ Explore above-ground
 
 
 
-Above-ground pool with deck package
+Hybrid Oasis with deck package
 
 
 
@@ -479,17 +479,19 @@ Above-ground pool with deck package
 
 
 
-Fiberglass In-Ground
-Factory-molded fiberglass shells with modern finishes.
-Choose Imagine Fiberglass shells with molded steps, benches, ledges, and equipment packages from Pentair dealers.
+In-Ground Pools
+Steel wall, vinyl liner, and fiberglass options.
+We separate steel wall in-ground builds, vinyl liner replacements, and fiberglass shell options during the quote so the material choice stays clear.
 
+Steel wall
+Vinyl liner
 Imagine Fiberglass
 
 Explore in-ground
 
 
 
-Fiberglass in-ground shell
+In-ground pool with splash pad
 
 
 
@@ -528,7 +530,7 @@ Explore liners
 
 
 
-Finished vinyl liner pool
+Steel wall in-ground pool
 
 
 
@@ -555,11 +557,11 @@ Source: https://www.us1pools.com/above-ground.html
 
 Above Ground
 Fast installs with clean, modern profiles.
-US-1 Pools installs above-ground pools with vinyl liner, resin, and steel options plus decks, stairs, and start-up service.
+US-1 Pools installs above-ground pools with vinyl liner, resin, steel, and Aquasport or Oasis hybrid options plus decks, stairs, and start-up service.
 
 Vinyl liner
 Resin systems
-Steel options
+Hybrid + steel
 
 
 
@@ -578,26 +580,26 @@ Discovery
 
 
 
-Representative above-ground deck package
-
-
-
-
-
-
-
-Yard-fit planning
-Above-ground installs can adapt to sloped yards.
-Some installs need retaining-wall or deck planning so the pool sits cleanly in the yard. We confirm the exact model, wall package, and site prep during the quote.
-
-Retaining walls
-Deck planning
-Site prep
-
-
-
-
 Above-ground pool with retaining wall
+
+
+
+
+
+
+
+Hybrid pools
+Aquasport and Oasis hybrid above-ground pools.
+Aquasport and Oasis are hybrid options to ask about when you want a stronger above-ground package with a clean finished profile. Oasis can only be recessed 27–30 inches in the ground.
+
+Aquasport
+Oasis
+27–30 in. max recess
+
+
+
+
+Hybrid Oasis with deck package
 
 
 
@@ -640,33 +642,35 @@ Get a Free Quote
 
 ---
 
-## In-Ground and Fiberglass Pools
+## In-Ground Pools
 Source: https://www.us1pools.com/in-ground.html
 
-In-Ground Materials
-Fiberglass shells and vinyl liner pools, clearly separated.
-US-1 Pools helps customers compare fiberglass in-ground shells, vinyl liner replacements, and the equipment upgrades that support both pool types.
+In-Ground Pools
+Steel wall, vinyl liner, and fiberglass options — clearly separated.
+US-1 Pools helps customers compare steel wall in-ground builds, vinyl liner replacements, fiberglass shell options, and the equipment that supports each pool type.
 
-Fiberglass shells
+Steel wall
 Vinyl liners
-Pentair systems
-
-
-
-
-
-
-
-Fiberglass shells
-Imagine Fiberglass shells.
-Imagine Fiberglass uses factory-molded shells with smooth gelcoat surfaces and integrated ledges, benches, steps, and swim zones.
-
 Imagine Fiberglass
 
 
 
 
-Fiberglass shell installation
+
+
+
+In-ground planning
+Steel wall, vinyl liner, and fiberglass options.
+We separate steel wall in-ground builds, vinyl liner replacements, and Imagine Fiberglass shell options during the quote. Features like splash pads are planned around the site.
+
+Steel wall
+Vinyl liner
+Imagine Fiberglass
+
+
+
+
+In-ground pool with splash pad
 
 
 
@@ -684,7 +688,7 @@ Latham
 
 
 
-Finished vinyl liner pool
+Steel wall in-ground pool at sunset
 
 
 
@@ -838,11 +842,11 @@ Overlap, beaded, and unibead styles in 20-mil and 25-mil thickness. Dozens of pa
 
 
 In-ground liners
-Custom-measured to your pool dimensions. 20-mil standard or 28-mil heavy-duty with wall foam backing.
+Custom-measured to your pool dimensions. 20-mil standard or 28-mil heavy-duty options. Wall foam can be requested as an add-on.
 
 
-Safety covers
-GLI also makes mesh and solid safety covers for winter protection — custom-fit to any pool shape.
+In-ground mesh safety covers
+GLI in-ground mesh safety covers are custom-fit for winter protection. Solid cover options are available when appropriate.
 
 
 
@@ -872,7 +876,7 @@ Latham's premium liner material with enhanced durability and stain resistance fo
 
 
 
-Finished vinyl liner pool
+Steel wall in-ground pool at sunset
 
 
 
@@ -1033,7 +1037,7 @@ Source: https://www.us1pools.com/gallery.html
 
 Gallery
 Projects built for light, water, and long weekends.
-Explore recent builds, liner replacements, fiberglass shells, above-ground installs, and construction progress across Franklin and surrounding counties. Filter by material type so the photos stay accurate.
+Explore recent builds, liner replacements, steel wall in-ground pools, above-ground installs, hybrid pools, and construction progress across Franklin and surrounding counties. Filter by material type so the photos stay accurate.
 
 
 
@@ -1041,28 +1045,29 @@ Explore recent builds, liner replacements, fiberglass shells, above-ground insta
 
 
 All
-Fiberglass
+In-ground
 Vinyl liner
 Above-ground
+Hybrid
 Construction
 
 
 
 
 
-Fiberglass in-ground shell
+In-ground pool with splash pad
 
 
 
-Finished vinyl liner pool at sunset
+Steel wall in-ground pool at sunset
 
 
 
-In-ground pool project
+In-ground pool with splash pad under construction
 
 
 
-Finished in-ground pool with deck
+Steel wall in-ground pool with deck
 
 
 
@@ -1074,11 +1079,11 @@ Above-ground equipment setup
 
 
 
-Above-ground deck and patio project
+Hybrid Oasis — 27–30 in. max recess
 
 
 
-Finished vinyl liner pool
+Aquasport hybrid above-ground pool
 
 
 
@@ -1102,7 +1107,7 @@ Residential pool installation
 
 
 
-Finished above-ground pool
+Aquasport hybrid above-ground pool
 
 
 
@@ -1328,7 +1333,7 @@ Standard pump, filter, and ladder/stairs.
 
 
 Mid-Level
-+ LED lighting, upgraded filter, heater.
++ upgraded filter, heater, automation-ready controls.
 +$3,000 - $5,000
 
 

--- a/llms.txt
+++ b/llms.txt
@@ -16,10 +16,10 @@ US-1 Pools handles the full pool lifecycle: above-ground installs, fiberglass in
 - [Home](https://www.us1pools.com/): Overview, services, testimonials, awards (2023 + 2025 Best of the Best)
 - [About](https://www.us1pools.com/about.html): Company history, founders Shayne and Cathy Parrish, certifications
 - [Pools and Spas overview](https://www.us1pools.com/pools.html): Above-ground systems, fiberglass in-ground shells, vinyl liner replacements, hot tubs
-- [Above-Ground Pools](https://www.us1pools.com/above-ground.html): Steel and resin above-ground systems with replaceable vinyl liners and optional deck packages. Genesis, Nakoma, and Discovery availability confirmed during quoting.
-- [Fiberglass and Vinyl Liner In-Ground](https://www.us1pools.com/in-ground.html): Fiberglass shells and vinyl liner pool options kept separate by material type. Imagine Fiberglass for fiberglass shells; Cardinal and Latham for vinyl liner work.
+- [Above-Ground Pools](https://www.us1pools.com/above-ground.html): Steel, resin, Aquasport hybrid, and Oasis hybrid above-ground systems with replaceable vinyl liners and optional deck packages. Oasis can only be recessed 27–30 inches; availability confirmed during quoting.
+- [In-Ground Pools](https://www.us1pools.com/in-ground.html): Steel wall in-ground builds, vinyl liner replacements, and fiberglass shell options kept separate by material type. Imagine Fiberglass for fiberglass shells; Cardinal and Latham for vinyl liner work.
 - [Hot Tubs and Spas](https://www.us1pools.com/hot-tubs.html): Stand-alone or integrated spas. Tranquility and Garden Leisure brands.
-- [Liners](https://www.us1pools.com/liners.html): Vinyl liner replacements and patterns from GLI Pool Products, Latham, and Cardinal.
+- [Liners](https://www.us1pools.com/liners.html): Vinyl liner replacements, GLI in-ground mesh safety covers, and patterns from GLI Pool Products, Latham, and Cardinal.
 - [Services](https://www.us1pools.com/services.html): Openings, closings, sand changes, equipment installs, liner changes, water testing.
 - [Gallery](https://www.us1pools.com/gallery.html): Project photos filtered by fiberglass, vinyl liner, above-ground, and construction categories.
 - [How-To Videos](https://www.us1pools.com/videos.html): Pool care tutorials.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Family-owned pool sales, service, and installation company in Franklinton, North Carolina. Founded 2015. NC licensed and CPO certified. Owners Shayne and Cathy Parrish have been in the pool industry since 1986. Serves Franklin and surrounding counties: Wake Forest, Youngsville, Louisburg, Raleigh, Durham, Henderson.
 
-US-1 Pools handles the full pool lifecycle: above-ground installs, fiberglass in-ground shells, vinyl liner replacements, hot tubs and swim spas, weekly maintenance, openings and closings, equipment repair, water testing, and retail (chemicals, cleaners, toys). Pool terminology matters: in-ground is the placement category; fiberglass shells and vinyl liner pools are different construction/material categories. Authorized dealer for Latham, GLI, Imagine Fiberglass, Pools by Genesis, Tranquility, Garden Leisure, and Maytronics Dolphin.
+US-1 Pools handles the full pool lifecycle: above-ground installs, fiberglass in-ground shells, vinyl liner replacements, hot tubs and swim spas, weekly maintenance, openings and closings, equipment repair, water testing, and retail (chemicals, cleaners, toys). Pool terminology matters: in-ground is the placement category; fiberglass shells and vinyl liner pools are different construction/material categories. Authorized dealer for Latham, GLI, Imagine Fiberglass, Genesis, Tranquility, Garden Leisure, and Maytronics Dolphin.
 
 ## Contact
 
@@ -16,12 +16,12 @@ US-1 Pools handles the full pool lifecycle: above-ground installs, fiberglass in
 - [Home](https://www.us1pools.com/): Overview, services, testimonials, awards (2023 + 2025 Best of the Best)
 - [About](https://www.us1pools.com/about.html): Company history, founders Shayne and Cathy Parrish, certifications
 - [Pools and Spas overview](https://www.us1pools.com/pools.html): Above-ground systems, fiberglass in-ground shells, vinyl liner replacements, hot tubs
-- [Above-Ground Pools](https://www.us1pools.com/above-ground.html): Steel, resin, and hybrid above-ground systems with replaceable vinyl liners and optional deck packages. Genesis, Nakoma, Discovery models.
-- [Fiberglass and Vinyl Liner In-Ground](https://www.us1pools.com/in-ground.html): Fiberglass shells and vinyl liner pool options kept separate by material type. Imagine Fiberglass, Pools by Genesis, Cardinal, and Latham.
+- [Above-Ground Pools](https://www.us1pools.com/above-ground.html): Steel and resin above-ground systems with replaceable vinyl liners and optional deck packages. Genesis, Nakoma, and Discovery availability confirmed during quoting.
+- [Fiberglass and Vinyl Liner In-Ground](https://www.us1pools.com/in-ground.html): Fiberglass shells and vinyl liner pool options kept separate by material type. Imagine Fiberglass for fiberglass shells; Cardinal and Latham for vinyl liner work.
 - [Hot Tubs and Spas](https://www.us1pools.com/hot-tubs.html): Stand-alone or integrated spas. Tranquility and Garden Leisure brands.
 - [Liners](https://www.us1pools.com/liners.html): Vinyl liner replacements and patterns from GLI Pool Products, Latham, and Cardinal.
 - [Services](https://www.us1pools.com/services.html): Openings, closings, sand changes, equipment installs, liner changes, water testing.
-- [Gallery](https://www.us1pools.com/gallery.html): Project photos filtered by fiberglass, vinyl liner, above-ground, construction, and lighting categories.
+- [Gallery](https://www.us1pools.com/gallery.html): Project photos filtered by fiberglass, vinyl liner, above-ground, and construction categories.
 - [How-To Videos](https://www.us1pools.com/videos.html): Pool care tutorials.
 - [Pool Cost Calculator](https://www.us1pools.com/calculator.html): Multi-step quiz that produces an instant price range.
 - [Contact](https://www.us1pools.com/contact.html): Quote request form, map, hours.

--- a/pools.html
+++ b/pools.html
@@ -96,8 +96,8 @@
       <div class="container content-grid">
         <div>
           <p class="eyebrow">Above Ground</p>
-          <h2>Fast installs with steel, resin, or hybrid wall systems.</h2>
-          <p class="section-sub">Above-ground pools use visible wall and frame systems with a replaceable vinyl liner inside. We help match the structure, liner style, and deck package to your yard.</p>
+          <h2>Fast installs with steel and resin wall systems.</h2>
+          <p class="section-sub">Above-ground pools use visible wall and frame systems with a replaceable vinyl liner inside. Model availability changes, so we match the structure, liner style, and deck package to your yard during the quote.</p>
           <div class="model-list">
             <span class="model-chip">Genesis</span>
             <span class="model-chip">Nakoma</span>
@@ -117,10 +117,9 @@
         <div>
           <p class="eyebrow">Fiberglass In-Ground</p>
           <h2>Factory-molded fiberglass shells with modern finishes.</h2>
-          <p class="section-sub">Choose from Imagine Fiberglass and Pools by Genesis shells, with molded steps, benches, ledges, and equipment packages from Pentair dealers.</p>
+          <p class="section-sub">Choose Imagine Fiberglass shells with molded steps, benches, ledges, and equipment packages from Pentair dealers.</p>
           <div class="model-list">
             <span class="model-chip">Imagine Fiberglass</span>
-            <span class="model-chip">Pools by Genesis</span>
           </div>
           <a class="btn btn-ghost" href="in-ground.html">Explore in-ground</a>
         </div>
@@ -144,8 +143,8 @@
           <a class="btn btn-ghost" href="hot-tubs.html">Explore Spas</a>
         </div>
         <div class="image-card">
-          <img src="assets/images/hero-secondary.webp" alt="Showroom spa care and water-care products for ongoing support" loading="lazy"  width="2500" height="1875" decoding="async"/>
-          <span class="image-caption">Showroom spa care support</span>
+          <img src="assets/images/hero-secondary.webp" alt="Pool chemicals, nets, and cleaning accessories in the US-1 Pools showroom" loading="lazy"  width="2500" height="1875" decoding="async"/>
+          <span class="image-caption">Showroom water-care supplies</span>
         </div>
       </div>
     </section>

--- a/pools.html
+++ b/pools.html
@@ -82,10 +82,10 @@
       <div class="container">
         <p class="eyebrow">Pools & Spas</p>
         <h1>Find the right pool for how you live outside.</h1>
-        <p>US-1 Pools separates the choice clearly: above-ground systems, fiberglass in-ground shells, vinyl liner replacement, and hot tubs or swim spas.</p>
+        <p>US-1 Pools separates the choice clearly: above-ground systems, in-ground steel wall, vinyl liner and fiberglass options, and hot tubs or swim spas.</p>
         <div class="page-meta">
           <span class="meta-chip">Above Ground</span>
-          <span class="meta-chip">Fiberglass Shells</span>
+          <span class="meta-chip">In-Ground</span>
           <span class="meta-chip">Vinyl Liners</span>
           <span class="meta-chip">Hot Tubs</span>
         </div>
@@ -96,8 +96,8 @@
       <div class="container content-grid">
         <div>
           <p class="eyebrow">Above Ground</p>
-          <h2>Fast installs with steel and resin wall systems.</h2>
-          <p class="section-sub">Above-ground pools use visible wall and frame systems with a replaceable vinyl liner inside. Model availability changes, so we match the structure, liner style, and deck package to your yard during the quote.</p>
+          <h2>Fast installs with steel, resin, and hybrid options.</h2>
+          <p class="section-sub">Above-ground pools use visible wall and frame systems with a replaceable vinyl liner inside. Model availability changes, so we match the structure, liner style, Aquasport or Oasis hybrid option, and deck package to your yard during the quote.</p>
           <div class="model-list">
             <span class="model-chip">Genesis</span>
             <span class="model-chip">Nakoma</span>
@@ -106,8 +106,8 @@
           <a class="btn btn-ghost" href="above-ground.html">Explore above-ground</a>
         </div>
         <div class="image-card">
-          <img src="assets/images/gallery-05.webp" alt="Above-ground pool with wraparound deck package" loading="lazy"  width="2500" height="1215" decoding="async"/>
-          <span class="image-caption">Above-ground pool with deck package</span>
+          <img src="assets/images/gallery-05.webp" alt="Hybrid Oasis above-ground pool with wraparound deck package" loading="lazy"  width="2500" height="1215" decoding="async"/>
+          <span class="image-caption">Hybrid Oasis with deck package</span>
         </div>
       </div>
     </section>
@@ -115,17 +115,19 @@
     <section class="section split reveal" id="in-ground">
       <div class="container content-grid content-grid--reverse">
         <div>
-          <p class="eyebrow">Fiberglass In-Ground</p>
-          <h2>Factory-molded fiberglass shells with modern finishes.</h2>
-          <p class="section-sub">Choose Imagine Fiberglass shells with molded steps, benches, ledges, and equipment packages from Pentair dealers.</p>
+          <p class="eyebrow">In-Ground Pools</p>
+          <h2>Steel wall, vinyl liner, and fiberglass options.</h2>
+          <p class="section-sub">We separate steel wall in-ground builds, vinyl liner replacements, and fiberglass shell options during the quote so the material choice stays clear.</p>
           <div class="model-list">
+            <span class="model-chip">Steel wall</span>
+            <span class="model-chip">Vinyl liner</span>
             <span class="model-chip">Imagine Fiberglass</span>
           </div>
           <a class="btn btn-ghost" href="in-ground.html">Explore in-ground</a>
         </div>
         <div class="image-card">
-          <img src="assets/images/gallery-04.webp" alt="Fiberglass in-ground pool shell with finished concrete deck" loading="lazy"  width="2500" height="1875" decoding="async"/>
-          <span class="image-caption">Fiberglass in-ground shell</span>
+          <img src="assets/images/gallery-04.webp" alt="In-ground pool with splash pad and finished concrete deck" loading="lazy"  width="2500" height="1875" decoding="async"/>
+          <span class="image-caption">In-ground pool with splash pad</span>
         </div>
       </div>
     </section>
@@ -163,8 +165,8 @@
           <a class="btn btn-ghost" href="liners.html">Explore liners</a>
         </div>
         <div class="image-card">
-          <img src="assets/images/customer-pool-sunset.webp" alt="Finished in-ground vinyl liner pool at sunset" loading="lazy"  width="1800" height="1350" decoding="async"/>
-          <span class="image-caption">Finished vinyl liner pool</span>
+          <img src="assets/images/customer-pool-sunset.webp" alt="Steel wall in-ground pool at sunset" loading="lazy"  width="1800" height="1350" decoding="async"/>
+          <span class="image-caption">Steel wall in-ground pool</span>
         </div>
       </div>
     </section>
@@ -253,7 +255,7 @@
                       {
                             "@type": "ListItem",
                             "position": 2,
-                            "name": "Fiberglass In-Ground Options",
+                            "name": "In-Ground Pool Options",
                             "url": "https://www.us1pools.com/in-ground.html"
                       },
                       {

--- a/scripts/build-llms-txt.mjs
+++ b/scripts/build-llms-txt.mjs
@@ -14,7 +14,7 @@ const PAGES = [
   { file: "about.html", url: "/about.html", title: "About" },
   { file: "pools.html", url: "/pools.html", title: "Pools and Spas Overview" },
   { file: "above-ground.html", url: "/above-ground.html", title: "Above-Ground Pools" },
-  { file: "in-ground.html", url: "/in-ground.html", title: "In-Ground and Fiberglass Pools" },
+  { file: "in-ground.html", url: "/in-ground.html", title: "In-Ground Pools" },
   { file: "hot-tubs.html", url: "/hot-tubs.html", title: "Hot Tubs and Swim Spas" },
   { file: "liners.html", url: "/liners.html", title: "Vinyl Liners" },
   { file: "services.html", url: "/services.html", title: "Services" },


### PR DESCRIPTION
## Summary
- remove unsupported LED-lighting photo/category claims
- relabel showroom brush/chemical photo as water-care supplies, not spa products
- correct above-ground/Genesis/fiberglass terminology per Cathy’s feedback
- rebuild llms-full.txt

## Checks
- npm run check
- local browser smoke: above-ground, in-ground, pools